### PR TITLE
Remove the Internal Package

### DIFF
--- a/de.marw.cdt.cmake.core/META-INF/MANIFEST.MF
+++ b/de.marw.cdt.cmake.core/META-INF/MANIFEST.MF
@@ -42,5 +42,7 @@ Import-Package: org.eclipse.cdt.core,
  org.osgi.framework
 Bundle-Activator: de.marw.cdt.cmake.core.CdtPlugin
 Export-Package: de.marw.cdt.cmake.core,
- de.marw.cdt.cmake.core.cmakecache
+ de.marw.cdt.cmake.core.cmakecache,
+ de.marw.cdt.cmake.core.settings,
+ de.marw.cdt.cmake.core.storage
 Require-Bundle: org.eclipse.ui

--- a/de.marw.cdt.cmake.core/plugin.xml
+++ b/de.marw.cdt.cmake.core/plugin.xml
@@ -10,7 +10,7 @@
       <builder
             autoBuildTarget="all"
             buildRunner="org.eclipse.cdt.managedbuilder.core.ExternalBuildRunner"
-            buildfileGenerator="de.marw.cdt.cmake.core.internal.BuildscriptGenerator"
+            buildfileGenerator="de.marw.cdt.cmake.core.BuildscriptGenerator"
             cleanBuildTarget="clean"
             command="make"
             errorParsers="org.eclipse.cdt.core.MakeErrorParser"
@@ -24,8 +24,8 @@
       </builder>
          <builder
                autoBuildTarget="all"
-               buildRunner="de.marw.cdt.cmake.core.internal.CmakeBuildRunner"
-               buildfileGenerator="de.marw.cdt.cmake.core.internal.BuildscriptGenerator"
+               buildRunner="de.marw.cdt.cmake.core.CmakeBuildRunner"
+               buildfileGenerator="de.marw.cdt.cmake.core.BuildscriptGenerator"
                cleanBuildTarget="clean"
                command="CMAKE_BUILD_TOOL"
                id="de.marw.cdt.cmake.core.genscriptbuilder"
@@ -39,7 +39,7 @@
          <!--
       <toolChain
             archList="all"
-            configurationMacroSupplier="de.marw.cdt.cmake.core.internal.CmakeOsMacroSupplier"
+            configurationMacroSupplier="de.marw.cdt.cmake.core.CmakeOsMacroSupplier"
             id="de.marw.cdt.cmake.core.toolChain"
             name="CMake portable"
             osList="all">
@@ -51,12 +51,12 @@
          </targetPlatform>
          <builder
                arguments="${cmake_build_cmd_earg}"
-               buildRunner="de.marw.cdt.cmake.core.internal.CmakeBuildRunner"
+               buildRunner="de.marw.cdt.cmake.core.CmakeBuildRunner"
                command="${cmake_build_cmd}"
                id="de.marw.cdt.cmake.core.genscriptbuilder"
                ignoreErrCmd="${cmake_ignore_err_option}"
                name="CMake Builder (portable)"
-               reservedMacroNameSupplier="de.marw.cdt.cmake.core.internal.CmakeOsMacroSupplier"
+               reservedMacroNameSupplier="de.marw.cdt.cmake.core.CmakeOsMacroSupplier"
                superClass="de.marw.cdt.cmake.core.genmakebuilder">
          </builder>
          <supportedProperties>

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/BuildscriptGenerator.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/BuildscriptGenerator.java
@@ -8,7 +8,7 @@
  * Contributors:
  *      Martin Weber - initial implementation
  *******************************************************************************/
-package de.marw.cdt.cmake.core.internal;
+package de.marw.cdt.cmake.core;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,12 +56,11 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubProgressMonitor;
 
-import de.marw.cdt.cmake.core.CdtPlugin;
-import de.marw.cdt.cmake.core.internal.settings.AbstractOsPreferences;
-import de.marw.cdt.cmake.core.internal.settings.CMakePreferences;
-import de.marw.cdt.cmake.core.internal.settings.CmakeDefine;
-import de.marw.cdt.cmake.core.internal.settings.CmakeUnDefine;
-import de.marw.cdt.cmake.core.internal.settings.ConfigurationManager;
+import de.marw.cdt.cmake.core.settings.AbstractOsPreferences;
+import de.marw.cdt.cmake.core.settings.CMakePreferences;
+import de.marw.cdt.cmake.core.settings.CmakeDefine;
+import de.marw.cdt.cmake.core.settings.CmakeUnDefine;
+import de.marw.cdt.cmake.core.settings.ConfigurationManager;
 
 /**
  * Generates makefiles and other build scripts from CMake scripts

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/CmakeBuildRunner.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/CmakeBuildRunner.java
@@ -8,7 +8,7 @@
  * Contributors:
  *      Martin Weber - Initial implementation
  *******************************************************************************/
-package de.marw.cdt.cmake.core.internal;
+package de.marw.cdt.cmake.core;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -52,13 +52,12 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.osgi.framework.Version;
 
-import de.marw.cdt.cmake.core.CdtPlugin;
 import de.marw.cdt.cmake.core.cmakecache.CMakeCacheFileParser;
 import de.marw.cdt.cmake.core.cmakecache.CMakeCacheFileParser.EntryFilter;
+import de.marw.cdt.cmake.core.settings.AbstractOsPreferences;
+import de.marw.cdt.cmake.core.settings.CMakePreferences;
+import de.marw.cdt.cmake.core.settings.ConfigurationManager;
 import de.marw.cdt.cmake.core.cmakecache.SimpleCMakeCacheEntry;
-import de.marw.cdt.cmake.core.internal.settings.AbstractOsPreferences;
-import de.marw.cdt.cmake.core.internal.settings.CMakePreferences;
-import de.marw.cdt.cmake.core.internal.settings.ConfigurationManager;
 
 /**
  * An ExternalBuildRunner that injects the build tool command to use and some of
@@ -157,7 +156,7 @@ public class CmakeBuildRunner extends ExternalBuildRunner {
      }
 
     // If getBuilderCWD() returns a workspace relative path, it gets garbled by CDT.
-    // If garbled, make sure de.marw.cdt.cmake.core.internal.BuildscriptGenerator.getBuildWorkingDir()
+    // If garbled, make sure de.marw.cdt.cmake.core.BuildscriptGenerator.getBuildWorkingDir()
     // returns a full, absolute path relative to the workspace.
     final IPath builderCWD = cfgd.getBuildSetting().getBuilderCWD();
 

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/CmakeGenerator.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/CmakeGenerator.java
@@ -8,7 +8,7 @@
  * Contributors:
  *      Martin Weber - Initial implementation
  *******************************************************************************/
-package de.marw.cdt.cmake.core.internal;
+package de.marw.cdt.cmake.core;
 
 /**
  * Represents a cmake build-script generator including information about the

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/settings/AbstractOsPreferences.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/settings/AbstractOsPreferences.java
@@ -8,7 +8,7 @@
  * Contributors:
  *      Martin Weber - Initial implementation
  *******************************************************************************/
-package de.marw.cdt.cmake.core.internal.settings;
+package de.marw.cdt.cmake.core.settings;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,10 +16,10 @@ import java.util.List;
 import org.eclipse.cdt.core.settings.model.ICStorageElement;
 import org.eclipse.core.runtime.Platform;
 
-import de.marw.cdt.cmake.core.internal.CmakeGenerator;
-import de.marw.cdt.cmake.core.internal.storage.CmakeDefineSerializer;
-import de.marw.cdt.cmake.core.internal.storage.CmakeUndefineSerializer;
-import de.marw.cdt.cmake.core.internal.storage.Util;
+import de.marw.cdt.cmake.core.CmakeGenerator;
+import de.marw.cdt.cmake.core.storage.CmakeDefineSerializer;
+import de.marw.cdt.cmake.core.storage.CmakeUndefineSerializer;
+import de.marw.cdt.cmake.core.storage.Util;
 
 /**
  * Preferences that override/augment the generic properties when running under a

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/settings/CMakePreferences.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/settings/CMakePreferences.java
@@ -8,7 +8,7 @@
  * Contributors:
  *      Martin Weber - Initial implementation
  *******************************************************************************/
-package de.marw.cdt.cmake.core.internal.settings;
+package de.marw.cdt.cmake.core.settings;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,9 +16,9 @@ import java.util.List;
 import org.eclipse.cdt.core.settings.model.ICStorageElement;
 
 import de.marw.cdt.cmake.core.CdtPlugin;
-import de.marw.cdt.cmake.core.internal.storage.CmakeDefineSerializer;
-import de.marw.cdt.cmake.core.internal.storage.CmakeUndefineSerializer;
-import de.marw.cdt.cmake.core.internal.storage.Util;
+import de.marw.cdt.cmake.core.storage.CmakeDefineSerializer;
+import de.marw.cdt.cmake.core.storage.CmakeUndefineSerializer;
+import de.marw.cdt.cmake.core.storage.Util;
 
 /**
  * Holds per-configuration project settings.

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/settings/CmakeDefine.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/settings/CmakeDefine.java
@@ -8,7 +8,7 @@
  * Contributors:
  *      Martin Weber - Initial implementation
  *******************************************************************************/
-package de.marw.cdt.cmake.core.internal.settings;
+package de.marw.cdt.cmake.core.settings;
 
 /**
  * Represents a cmake variable to define.

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/settings/CmakeUnDefine.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/settings/CmakeUnDefine.java
@@ -8,7 +8,7 @@
  * Contributors:
  *      Martin Weber - Initial implementation
  *******************************************************************************/
-package de.marw.cdt.cmake.core.internal.settings;
+package de.marw.cdt.cmake.core.settings;
 
 /**
  * Represents a cmake variable to undefine.

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/settings/CmakeVariableType.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/settings/CmakeVariableType.java
@@ -8,7 +8,7 @@
  * Contributors:
  *      Martin Weber - Initial implementation
  *******************************************************************************/
-package de.marw.cdt.cmake.core.internal.settings;
+package de.marw.cdt.cmake.core.settings;
 
 /**
  * The type identifier of a cmake variable.

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/settings/ConfigurationManager.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/settings/ConfigurationManager.java
@@ -8,7 +8,7 @@
  * Contributors:
  *      Martin Weber - Initial implementation
  *******************************************************************************/
-package de.marw.cdt.cmake.core.internal.settings;
+package de.marw.cdt.cmake.core.settings;
 
 import java.util.WeakHashMap;
 

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/settings/LinuxPreferences.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/settings/LinuxPreferences.java
@@ -8,28 +8,33 @@
  * Contributors:
  *      Martin Weber - Initial implementation
  *******************************************************************************/
-package de.marw.cdt.cmake.core.internal.settings;
+package de.marw.cdt.cmake.core.settings;
 
-import de.marw.cdt.cmake.core.internal.CmakeGenerator;
 
 /**
  * Preferences that override/augment the generic properties when running under
- * Windows.
+ * Linux.
  *
  * @author Martin Weber
  */
-public class WindowsPreferences extends AbstractOsPreferences {
+public class LinuxPreferences extends AbstractOsPreferences {
 
-  private static final String ELEM_OS = "win32";
-
-  /** Overridden to set a sensible generator. */
-  public void reset() {
-    super.reset();
-    setGenerator(CmakeGenerator.MinGWMakefiles);
-  }
+  private static final String ELEM_OS = "linux";
 
   /**
-   * @return the String "win32".
+   * Creates a new object, initialized with all default values.
+   */
+  public LinuxPreferences() {
+  }
+
+//  /** Overridden to set a sensible generator. */
+//  public void reset() {
+//    super.reset();
+//    setGenerator( CmakeGenerator.UnixMakefiles);
+//  }
+
+  /**
+   * @return the String "linux".
    */
   protected String getStorageElementName() {
     return ELEM_OS;

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/settings/WindowsPreferences.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/settings/WindowsPreferences.java
@@ -8,33 +8,28 @@
  * Contributors:
  *      Martin Weber - Initial implementation
  *******************************************************************************/
-package de.marw.cdt.cmake.core.internal.settings;
+package de.marw.cdt.cmake.core.settings;
 
+import de.marw.cdt.cmake.core.CmakeGenerator;
 
 /**
  * Preferences that override/augment the generic properties when running under
- * Linux.
+ * Windows.
  *
  * @author Martin Weber
  */
-public class LinuxPreferences extends AbstractOsPreferences {
+public class WindowsPreferences extends AbstractOsPreferences {
 
-  private static final String ELEM_OS = "linux";
+  private static final String ELEM_OS = "win32";
 
-  /**
-   * Creates a new object, initialized with all default values.
-   */
-  public LinuxPreferences() {
+  /** Overridden to set a sensible generator. */
+  public void reset() {
+    super.reset();
+    setGenerator(CmakeGenerator.MinGWMakefiles);
   }
 
-//  /** Overridden to set a sensible generator. */
-//  public void reset() {
-//    super.reset();
-//    setGenerator( CmakeGenerator.UnixMakefiles);
-//  }
-
   /**
-   * @return the String "linux".
+   * @return the String "win32".
    */
   protected String getStorageElementName() {
     return ELEM_OS;

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/storage/CmakeDefineSerializer.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/storage/CmakeDefineSerializer.java
@@ -8,12 +8,12 @@
  * Contributors:
  *      Martin Weber - Initial implementation
  *******************************************************************************/
-package de.marw.cdt.cmake.core.internal.storage;
+package de.marw.cdt.cmake.core.storage;
 
 import org.eclipse.cdt.core.settings.model.ICStorageElement;
 
-import de.marw.cdt.cmake.core.internal.settings.CmakeDefine;
-import de.marw.cdt.cmake.core.internal.settings.CmakeVariableType;
+import de.marw.cdt.cmake.core.settings.CmakeDefine;
+import de.marw.cdt.cmake.core.settings.CmakeVariableType;
 
 /**
  * Responsible for serialization/de-serialization of CmakeDefine objects.

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/storage/CmakeUndefineSerializer.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/storage/CmakeUndefineSerializer.java
@@ -8,11 +8,11 @@
  * Contributors:
  *      Martin Weber - Initial implementation
  *******************************************************************************/
-package de.marw.cdt.cmake.core.internal.storage;
+package de.marw.cdt.cmake.core.storage;
 
 import org.eclipse.cdt.core.settings.model.ICStorageElement;
 
-import de.marw.cdt.cmake.core.internal.settings.CmakeUnDefine;
+import de.marw.cdt.cmake.core.settings.CmakeUnDefine;
 
 /**
  * Responsible for serialization/de-serialization of CmakeUndefine objects.
@@ -32,7 +32,7 @@ public class CmakeUndefineSerializer implements
   }
 
   /*-
-   * @see de.marw.cdt.cmake.core.internal.storage.StorageSerializer#fromStorage(org.eclipse.cdt.core.settings.model.ICStorageElement)
+   * @see de.marw.cdt.cmake.core.storage.StorageSerializer#fromStorage(org.eclipse.cdt.core.settings.model.ICStorageElement)
    */
   @Override
   public CmakeUnDefine fromStorage(ICStorageElement item) {

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/storage/StorageSerializer.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/storage/StorageSerializer.java
@@ -8,7 +8,7 @@
  * Contributors:
  *      Martin Weber - Initial implementation
  *******************************************************************************/
-package de.marw.cdt.cmake.core.internal.storage;
+package de.marw.cdt.cmake.core.storage;
 
 import org.eclipse.cdt.core.settings.model.ICStorageElement;
 

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/storage/Util.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/storage/Util.java
@@ -8,7 +8,7 @@
  * Contributors:
  *      Martin Weber - Initial implementation
  *******************************************************************************/
-package de.marw.cdt.cmake.core.internal.storage;
+package de.marw.cdt.cmake.core.storage;
 
 import java.util.Collection;
 

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/ui/AbstractOsPropertyTab.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/ui/AbstractOsPropertyTab.java
@@ -40,12 +40,12 @@ import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Text;
 
 import de.marw.cdt.cmake.core.CdtPlugin;
-import de.marw.cdt.cmake.core.internal.CmakeGenerator;
-import de.marw.cdt.cmake.core.internal.settings.AbstractOsPreferences;
-import de.marw.cdt.cmake.core.internal.settings.CMakePreferences;
-import de.marw.cdt.cmake.core.internal.settings.CmakeDefine;
-import de.marw.cdt.cmake.core.internal.settings.CmakeUnDefine;
-import de.marw.cdt.cmake.core.internal.settings.ConfigurationManager;
+import de.marw.cdt.cmake.core.CmakeGenerator;
+import de.marw.cdt.cmake.core.settings.AbstractOsPreferences;
+import de.marw.cdt.cmake.core.settings.CMakePreferences;
+import de.marw.cdt.cmake.core.settings.CmakeDefine;
+import de.marw.cdt.cmake.core.settings.CmakeUnDefine;
+import de.marw.cdt.cmake.core.settings.ConfigurationManager;
 
 /**
  * Generic UI to control host OS specific project properties and preferences for

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/ui/AddCmakeDefineDialog.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/ui/AddCmakeDefineDialog.java
@@ -33,8 +33,8 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 
 import de.marw.cdt.cmake.core.CdtPlugin;
-import de.marw.cdt.cmake.core.internal.settings.CmakeDefine;
-import de.marw.cdt.cmake.core.internal.settings.CmakeVariableType;
+import de.marw.cdt.cmake.core.settings.CmakeDefine;
+import de.marw.cdt.cmake.core.settings.CmakeVariableType;
 
 /**
  * The dialog used to create or edit a cmake define.

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/ui/AddCmakeUndefineDialog.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/ui/AddCmakeUndefineDialog.java
@@ -26,7 +26,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 
 import de.marw.cdt.cmake.core.CdtPlugin;
-import de.marw.cdt.cmake.core.internal.settings.CmakeUnDefine;
+import de.marw.cdt.cmake.core.settings.CmakeUnDefine;
 
 /**
  * The dialog used to create or edit a cmake undefine.

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/ui/CMakePropertyTab.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/ui/CMakePropertyTab.java
@@ -41,8 +41,8 @@ import org.eclipse.ui.dialogs.FilteredResourcesSelectionDialog;
 import org.eclipse.ui.dialogs.NewFolderDialog;
 
 import de.marw.cdt.cmake.core.CdtPlugin;
-import de.marw.cdt.cmake.core.internal.settings.CMakePreferences;
-import de.marw.cdt.cmake.core.internal.settings.ConfigurationManager;
+import de.marw.cdt.cmake.core.settings.CMakePreferences;
+import de.marw.cdt.cmake.core.settings.ConfigurationManager;
 
 /**
  * UI to control general project properties for cmake. This tab is responsible

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/ui/CMakeSymbolsTab.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/ui/CMakeSymbolsTab.java
@@ -24,10 +24,10 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 
 import de.marw.cdt.cmake.core.CdtPlugin;
-import de.marw.cdt.cmake.core.internal.settings.CMakePreferences;
-import de.marw.cdt.cmake.core.internal.settings.CmakeDefine;
-import de.marw.cdt.cmake.core.internal.settings.CmakeUnDefine;
-import de.marw.cdt.cmake.core.internal.settings.ConfigurationManager;
+import de.marw.cdt.cmake.core.settings.CMakePreferences;
+import de.marw.cdt.cmake.core.settings.CmakeDefine;
+import de.marw.cdt.cmake.core.settings.CmakeUnDefine;
+import de.marw.cdt.cmake.core.settings.ConfigurationManager;
 
 /**
  * UI to control general project properties for cmake. This tab is responsible

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/ui/DefinesViewer.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/ui/DefinesViewer.java
@@ -44,7 +44,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 
-import de.marw.cdt.cmake.core.internal.settings.CmakeDefine;
+import de.marw.cdt.cmake.core.settings.CmakeDefine;
 
 /**
  * Displays a table for the Cmake defines. The created table will be displayed

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/ui/LinuxPropertyTab.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/ui/LinuxPropertyTab.java
@@ -12,9 +12,9 @@ package de.marw.cdt.cmake.core.ui;
 
 import java.util.EnumSet;
 
-import de.marw.cdt.cmake.core.internal.CmakeGenerator;
-import de.marw.cdt.cmake.core.internal.settings.CMakePreferences;
-import de.marw.cdt.cmake.core.internal.settings.LinuxPreferences;
+import de.marw.cdt.cmake.core.CmakeGenerator;
+import de.marw.cdt.cmake.core.settings.CMakePreferences;
+import de.marw.cdt.cmake.core.settings.LinuxPreferences;
 
 /**
  * UI to control host Linux specific project properties and preferences for
@@ -28,7 +28,7 @@ public class LinuxPropertyTab extends AbstractOsPropertyTab<LinuxPreferences> {
       .of(CmakeGenerator.UnixMakefiles,CmakeGenerator.Ninja);
 
   /*-
-   * @see de.marw.cdt.cmake.core.ui.AbstractOsPropertyTab#getOsPreferences(de.marw.cdt.cmake.core.internal.CMakePreferences)
+   * @see de.marw.cdt.cmake.core.ui.AbstractOsPropertyTab#getOsPreferences(de.marw.cdt.cmake.core.settings.CMakePreferences)
    */
   @Override
   protected LinuxPreferences getOsPreferences(CMakePreferences prefs) {

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/ui/UnDefinesViewer.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/ui/UnDefinesViewer.java
@@ -43,7 +43,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 
-import de.marw.cdt.cmake.core.internal.settings.CmakeUnDefine;
+import de.marw.cdt.cmake.core.settings.CmakeUnDefine;
 
 /**
  * Displays a table for the Cmake undefines. The created table will be displayed

--- a/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/ui/WindowsPropertyTab.java
+++ b/de.marw.cdt.cmake.core/src/main/java/de/marw/cdt/cmake/core/ui/WindowsPropertyTab.java
@@ -12,9 +12,9 @@ package de.marw.cdt.cmake.core.ui;
 
 import java.util.EnumSet;
 
-import de.marw.cdt.cmake.core.internal.CmakeGenerator;
-import de.marw.cdt.cmake.core.internal.settings.CMakePreferences;
-import de.marw.cdt.cmake.core.internal.settings.WindowsPreferences;
+import de.marw.cdt.cmake.core.CmakeGenerator;
+import de.marw.cdt.cmake.core.settings.CMakePreferences;
+import de.marw.cdt.cmake.core.settings.WindowsPreferences;
 
 /**
  * UI to control host Windows specific project properties and preferences for
@@ -32,7 +32,7 @@ public class WindowsPropertyTab extends
       CmakeGenerator.BorlandMakefiles, CmakeGenerator.WatcomWMake);
 
   /*-
-   * @see de.marw.cdt.cmake.core.ui.AbstractOsPropertyTab#getOsPreferences(de.marw.cdt.cmake.core.internal.CMakePreferences)
+   * @see de.marw.cdt.cmake.core.ui.AbstractOsPropertyTab#getOsPreferences(de.marw.cdt.cmake.core.settings.CMakePreferences)
    */
   @Override
   protected WindowsPreferences getOsPreferences(CMakePreferences prefs) {

--- a/de.marw.cdt.cmake.core/src/test/java/de/marw/cdt/cmake/core/CmakeGeneratorTest.java
+++ b/de.marw.cdt.cmake.core/src/test/java/de/marw/cdt/cmake/core/CmakeGeneratorTest.java
@@ -9,12 +9,14 @@
  *      Martin Weber - Initial implementation
  *******************************************************************************/
 
-package de.marw.cdt.cmake.core.internal;
+package de.marw.cdt.cmake.core;
 
 import static org.junit.Assert.*;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import de.marw.cdt.cmake.core.CmakeGenerator;
 
 /**
  * @author weber
@@ -31,7 +33,7 @@ public class CmakeGeneratorTest {
 
   /**
    * Test method for
-   * {@link de.marw.cdt.cmake.core.internal.CmakeGenerator#getParallelBuildArg(int)}.
+   * {@link de.marw.cdt.cmake.core.CmakeGenerator#getParallelBuildArg(int)}.
    */
   @Test
   public void testGetParallelBuildArg_Off() {
@@ -47,7 +49,7 @@ public class CmakeGeneratorTest {
 
   /**
    * Test method for
-   * {@link de.marw.cdt.cmake.core.internal.CmakeGenerator#getParallelBuildArg(int)}.
+   * {@link de.marw.cdt.cmake.core.CmakeGenerator#getParallelBuildArg(int)}.
    */
   @Test
   public void testGetParallelBuildArg_Unlimited() {
@@ -63,7 +65,7 @@ public class CmakeGeneratorTest {
 
   /**
    * Test method for
-   * {@link de.marw.cdt.cmake.core.internal.CmakeGenerator#getParallelBuildArg(int)}.
+   * {@link de.marw.cdt.cmake.core.CmakeGenerator#getParallelBuildArg(int)}.
    */
   @Test
   public void testGetParallelBuildArg_User() {

--- a/de.marw.cmake/src/main/java/de/marw/cmake/cdt/language/settings/providers/CmakeBuildOutputParser.java
+++ b/de.marw.cmake/src/main/java/de/marw/cmake/cdt/language/settings/providers/CmakeBuildOutputParser.java
@@ -119,7 +119,7 @@ public class CmakeBuildOutputParser extends LanguageSettingsSerializableProvider
     SimpleCMakeCacheTxt cmCache = null;
 
     // If getBuilderCWD() returns a workspace relative path, it is garbled.
-    // If garbled, make sure de.marw.cdt.cmake.core.internal.BuildscriptGenerator.getBuildWorkingDir()
+    // If garbled, make sure de.marw.cdt.cmake.core.BuildscriptGenerator.getBuildWorkingDir()
     // returns a full, absolute path relative to the workspace.
     final IPath builderCWD = cfgd.getBuildSetting().getBuilderCWD();
 


### PR DESCRIPTION
- Remove the Internal Package to make them discoverable by third party
  plugins.
- Merge de.marw.cdt.cmake.core.internal with de.marw.cdt.cmake.core.
- Move all classes from de.marw.cdt.cmake.core.internal.settings to
  de.marw.cdt.cmake.core.settings.
- Move all classes from de.marw.cdt.cmake.core.internal.storage to
  de.marw.cdt.cmake.core.storage.
- Update all references to the internal package to the new package
  names.